### PR TITLE
Remove version and add CRM card location configuration property

### DIFF
--- a/src/app/app.json
+++ b/src/app/app.json
@@ -10,8 +10,7 @@
     "crm": {
       "cards": [
         {
-          "file": "./crm-card.json",
-          "version": "2"
+          "file": "./crm-card.json"
         }
       ]
     }

--- a/src/app/crm-card.json
+++ b/src/app/crm-card.json
@@ -1,15 +1,15 @@
 {
   "type": "crm-card",
-  "version": "2",
   "data": {
     "title": "Example CRM Card",
+    "location": "crm.record.tab",
     "fetch": {
       "targetFunction": "crm-card",
       "objectTypes": [
         {
           "name": "contacts",
           "propertiesToSend": ["firstname"],
-          "actions":[]
+          "actions": []
         }
       ]
     }


### PR DESCRIPTION
`"location"` is the new configuration property used to specify where a CRM card extension should render, currently either `"crm.record.tab"` and `"crm.record.sidebar"`.

I've tested this with both locations, everything works as intended.